### PR TITLE
Fix sorting edge cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30.1)
+cmake_minimum_required(VERSION 3.28)
 
 project(Sorting VERSION 1.2.0)
 

--- a/src/sort/bogo.cpp
+++ b/src/sort/bogo.cpp
@@ -10,11 +10,16 @@ BogoSort::BogoSort(std::vector<int>& t_arr) : BaseSort(t_arr) {}
 
 bool BogoSort::isSorted()
 {
-    size_t n = elems.size();
-    while (--n > 0) {
-        if (elems[n] < elems[n - 1])
-            return false;
+    if (elems.empty()) {
+        return true;
     }
+
+    for (size_t i = 1; i < elems.size(); ++i) {
+        if (elems[i] < elems[i - 1]) {
+            return false;
+        }
+    }
+
     return true;
 }
 

--- a/src/sort/pigeon_hole.cpp
+++ b/src/sort/pigeon_hole.cpp
@@ -12,7 +12,11 @@ void PigeonHoleSort::sort()
 {
     isSorting = true;
     int n = elems.size();
-    if (n == 0) return;
+    if (n == 0) {
+        isSorting = false;
+        sorted = true;
+        return;
+    }
 
     int min = elems[0], max = elems[0];
     for (int i = 1; i < n; i++)


### PR DESCRIPTION
## Summary
- handle empty list in `BogoSort::isSorted`
- correctly finish `PigeonHoleSort` when array is empty
- lower the minimum required CMake version